### PR TITLE
Ajustes na rotina de exportação de pautas

### DIFF
--- a/extensoes/pr_snas/1.7/classes/VinculacaoDemanda.php
+++ b/extensoes/pr_snas/1.7/classes/VinculacaoDemanda.php
@@ -443,7 +443,8 @@ class VinculacaoDemanda extends Vinculacao {
 	    	$sql .= 'from sgdoc.tb_documentos_vinculacao v ';
 	    	$sql .= 'inner join sgdoc.tb_documentos_cadastro d on (d.id=v.' . ($relacao == 'p' ? 'id_documento_filho' : 'id_documento_pai') . ') ';
 	    	$sql .= 'where (v.st_ativo = 1) and (v.id_vinculacao = :vinc) ';
-	    	$sql .= 'and (v.' . ($relacao == 'p' ? 'id_documento_pai' : 'id_documento_filho') . ' = :id);';
+	    	$sql .= 'and (v.' . ($relacao == 'p' ? 'id_documento_pai' : 'id_documento_filho') . ' = :id) ';
+	    	$sql .= 'order by d.digital;';
 	    	
 	    	$stmt = Controlador::getInstance()->getConnection()->connection->prepare($sql);
 	    	

--- a/extensoes/pr_snas/1.7/modelos/documentos/exportar_documentos_configuravel.php
+++ b/extensoes/pr_snas/1.7/modelos/documentos/exportar_documentos_configuravel.php
@@ -165,7 +165,11 @@ if ($_POST) {
 					if ($arrDem !== false) {
 						for ($i=0; $i<count($arrDem); $i++) {
 							$prazo = DaoPrazoDemanda::getPrimeiroPrazo($arrDem[$i]['DIGITAL']);
-							$prazo['legislacao_situacao'] = DaoPrazoDemanda::getSituacaoLegislacao($prazo['legislacao_situacao']);
+							if (is_null($prazo['dt_resposta'])) {
+								$prazo['legislacao_situacao'] = '';
+							} else {
+								$prazo['legislacao_situacao'] = $prazo['legislacao_situacao_descricao'];
+							}
 							fwrite($fp, "\n----- DEMANDA " . ($i+1) . " -----\n");
 							foreach ($arrOpcSel as $opt) {
 								if (($opt != 'prz-ppa') && ($opt != 'prz-exec_orc')) {


### PR DESCRIPTION
Ajustes na rotina de exportação de pautas, ordenando as demandas pela digital e para demandas sem resposta não exportar descrição da situação legislação.